### PR TITLE
Add Oauth token auto-renewal

### DIFF
--- a/Token.php
+++ b/Token.php
@@ -5,11 +5,12 @@ use Buzz\Browser;
 
 /**
  * Class Token
- *
  * @package Lasso\Oauth2ClientBundle
  */
 class Token
 {
+    const DEFAULT_EXPIRES_IN = 3600;
+
     /**
      * @var string
      */
@@ -36,6 +37,17 @@ class Token
     protected $token;
 
     /**
+     * UTC Timestamp(number of seconds since the Unix Epoch)
+     * of when token was last acquired.
+     */
+    protected $whenAcquired;
+
+    /**
+     * TTL of token in seconds.
+     */
+    protected $expires_in = Token::DEFAULT_EXPIRES_IN;
+
+    /**
      * @param string  $clientId
      * @param string  $clientSecret
      * @param string  $tokenUrl
@@ -53,6 +65,7 @@ class Token
     }
 
     /**
+     *
      * @return string
      */
     protected function acquireToken()
@@ -65,8 +78,10 @@ class Token
 
         $url = $this->tokenUrl . '?' . $query;
 
-        $response = $this->browser->get($url)->getContent();
-        $response = json_decode($response, true);
+        $response           = $this->browser->get($url)->getContent();
+        $response           = json_decode($response, true);
+        $this->whenAcquired = time();
+        $this->expires_in   = isset($response['expires_in']) ? $response['expires_in'] : Token::DEFAULT_EXPIRES_IN;
 
         return $response['access_token'];
     }
@@ -78,7 +93,9 @@ class Token
      */
     public function getToken()
     {
-        if (empty($this->token)) {
+        if (empty($this->token) ||
+            (time() - $this->whenAcquired) >= $this->expires_in
+        ) {
             $this->token = $this->acquireToken();
         }
 


### PR DESCRIPTION
Reason: Oauth token would silently expire and cause strange errors and side-effects